### PR TITLE
Bump documentation link to the 4.3.7 series

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         </div>
         <div class='float-right'>
           <a href="https://github.com/greenplum-db/greenplum-db.github.io/wiki">Wiki</a>
-          <a href="http://gpdb.docs.pivotal.io/4360/common/welcome.html">Documentation</a>
+          <a href="http://gpdb.docs.pivotal.io/4370/common/welcome.html">Documentation</a>
           <a href="https://github.com/greenplum-db/gpdb">Code</a>
           <a href="http://greenplum.org/gpdb-sandbox-tutorials/">Tutorials</a>
 
@@ -162,7 +162,7 @@
     <div id='learnmore' class='bg-blue'>
       <h2>Learn More:</h2>
       <div class='cta'><a href='https://github.com/greenplum-db/greenplum-db.github.io/wiki'>Wiki</a></div>
-      <div class='cta'><a href='http://gpdb.docs.pivotal.io/4360/common/welcome.html'>Documentation</a></div>
+      <div class='cta'><a href='http://gpdb.docs.pivotal.io/4370/common/welcome.html'>Documentation</a></div>
     </div>
 
     <div id='mailing-lists'>


### PR DESCRIPTION
It would be nice if we had a `/current/` or `/latest/` URL rewrite for the documentation so we don't have to maintain this link manually but until then let's make it point at the most recent version.