### PR TITLE
Alter Documentation link to always point to current

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         </div>
         <div class='float-right'>
           <a href="https://github.com/greenplum-db/greenplum-db.github.io/wiki">Wiki</a>
-          <a href="http://gpdb.docs.pivotal.io/4370/common/welcome.html">Documentation</a>
+          <a href="http://gpdb.docs.pivotal.io/">Documentation</a>
           <a href="https://github.com/greenplum-db/gpdb">Code</a>
           <a href="http://greenplum.org/gpdb-sandbox-tutorials/">Tutorials</a>
 
@@ -162,7 +162,7 @@
     <div id='learnmore' class='bg-blue'>
       <h2>Learn More:</h2>
       <div class='cta'><a href='https://github.com/greenplum-db/greenplum-db.github.io/wiki'>Wiki</a></div>
-      <div class='cta'><a href='http://gpdb.docs.pivotal.io/4370/common/welcome.html'>Documentation</a></div>
+      <div class='cta'><a href='http://gpdb.docs.pivotal.io/'>Documentation</a></div>
     </div>
 
     <div id='mailing-lists'>


### PR DESCRIPTION
Rather than constantly bumping the documentation link when a new release is out we can use http://gpdb.docs.pivotal.io/ which will redirect to the current version.

Reported by Mel Kiyama