### PR TITLE
Remove O'Reilly Strata from the events section

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,16 +203,6 @@
         <h2>Greenplum Events</h2>
         <div class='events'>
           <div class='event'>
-            <a href='http://conferences.oreilly.com/strata/hadoop-big-data-ca'>
-              <div class='inner'>
-                <div class='date'>March 29-31</div>
-                <div id='strata' class='img'><img src='images/events/event-stratahadoop.png' alt='Strata Hadoop World' /></div>
-                <h4>Strata + Hadoop World</h4>
-                <p>San Jose, California</p>
-              </div>
-            </a>
-          </div>
-          <div class='event'>
             <a href='http://www.pgconf.us/2016/'>
               <div class='inner'>
                 <div class='date'>April 18-20</div>


### PR DESCRIPTION
The Strata conference is now over so remove from the event section on our website. Will push this shortly unless objections.