### PR TITLE
Remove the PGConf.US event from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,16 +198,6 @@
         <h2>Greenplum Events</h2>
         <div class='events'>
           <div class='event'>
-            <a href='http://www.pgconf.us/2016/'>
-              <div class='inner'>
-                <div class='date'>April 18-20</div>
-                <div id='pgconf' class='img'><img src='images/events/pgconf2016us.png' alt='PGConf US' /></div>
-                <h4>PostgreSQL Conference US 2016</h4>
-                <p>New York, USA</p>
-              </div>
-            </a>
-          </div>
-          <div class='event'>
             <a href='http://greenplum.meetup.com/'>
               <div class='inner'>
                 <div class='date'>Ongoing</div>


### PR DESCRIPTION
The conference is now over so remove the event box from the index page.