### PR TITLE
Contribute section

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
               <h3>Tell us about your Greenplum experience</h3>
               <p>Use the <a href='mailto:gpdb-users@greenplum.org'>gpdb-users@greenplum.org</a> mailing list to share any kind of questions related to installation, configuration, usage, product documentation or any other area you might need help with. Feel free to send us your links to blogs and presentations so we can highlight them on greenplum.org. Alternatively you can also be a part of the Greenplum discussions on Stack Overflow. </p>
               <ul>
-                <li>Greenplum users mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-users">Read</a> &middot; <a href='mailto:gpdb-users+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-users@greenplum.org'>Post</a> &middot; <a href='mailto:gpdb-users+unsubscribe@greenplum.org'>Unsubscribe</a></li>
+                <li>Greenplum users mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-users">Read</a> &middot; <a href='mailto:gpdb-users+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-users@greenplum.org'>Post</a></li>
                 <li><a href='http://stackoverflow.com/questions/tagged/greenplum'>Greenplum on Stack Overflow</a></li>
               </ul>
             </div>
@@ -123,7 +123,7 @@
               <h3>Greenplum code</h3>
               <p>Do you have an idea for a new feature or bug fix for Greenplum? Please discuss in the <a href='mailto:gpdb-dev@greenplum.org'>gpdb-dev@greenplum.org</a> mailing list or make pull requests on Github. </p>
               <ul>
-                <li>Greenplum dev mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-dev">Read</a> &middot; <a href='mailto:gpdb-dev+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-dev@greenplum.org'>Post</a> &middot; <a href='mailto:gpdb-dev+unsubscribe@greenplum.org'>Unsubscribe</a></li>
+                <li>Greenplum dev mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-dev">Read</a> &middot; <a href='mailto:gpdb-dev+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-dev@greenplum.org'>Post</a></li>
                 <li><a href='https://github.com/greenplum-db'>Greenplum on GitHub</a></li>
                 <li><a href='contributor_agreements/GPDB_Pivotal_ICLA.pdf'>Individual Contributor License Agreement</a></li>
                 <li><a href='contributor_agreements/GPDB_Pivotal_CCLA.pdf'>Corporate Contributor License Agreement</a></li>
@@ -135,7 +135,7 @@
               <h3>Evangelism</h3>
               <p>Are you a Greenplum expert? Want to share your knowledge with others? We are a collaborative community that shares best practices.</p>
               <ul>
-                <li>Greenplum users mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-users">Read</a> &middot; <a href='mailto:gpdb-users+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-users@greenplum.org'>Post</a> &middot; <a href='mailto:gpdb-users+unsubscribe@greenplum.org'>Unsubscribe</a></li>
+                <li>Greenplum users mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-users">Read</a> &middot; <a href='mailto:gpdb-users+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-users@greenplum.org'>Post</a></li>
                 <li><a href='#events'>Greenplum Events</a></li>
                 <li><a href='https://twitter.com/greenplum'>Greenplum on Twitter</a></li>
               </ul>

--- a/index.html
+++ b/index.html
@@ -135,8 +135,8 @@
               <h3>Evangelism</h3>
               <p>Are you a Greenplum expert? Want to share your knowledge with others? We are a collaborative community that shares best practices.</p>
               <ul>
+                <li>Greenplum users mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-users">Read</a> &middot; <a href='mailto:gpdb-users+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-users@greenplum.org'>Post</a> &middot; <a href='mailto:gpdb-users+unsubscribe@greenplum.org'>Unsubscribe</a></li>
                 <li><a href='#events'>Greenplum Events</a></li>
-                <li><a href='mailto:gpdb-users@greenplum.org'>Greenplum users mail list</a></li>
                 <li><a href='https://twitter.com/greenplum'>Greenplum on Twitter</a></li>
               </ul>
             </div>


### PR DESCRIPTION
Two changes on the contribute section;

The users mailinglist in the evangelism box only had a mailto link while the other boxes had all the options. Put all the options also for evangelism to make it consistent.

Remove Unsubscribe options from Contribute section. It doesn't make much sense to present unsubscribe options for the mailing lists in the contribute section, the call to action is to contribute which unsubscribing can't be classified as. We have full unsubscribe options in the mailinglist section to remove from here to unclutter the page.

