### PR TITLE
Add links to the Greenplum Youtube channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
                 <li>Greenplum users mailing list: <a href="https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-users">Read</a> &middot; <a href='mailto:gpdb-users+subscribe@greenplum.org'>Subscribe</a> &middot; <a href='mailto:gpdb-users@greenplum.org'>Post</a></li>
                 <li><a href='#events'>Greenplum Events</a></li>
                 <li><a href='https://twitter.com/greenplum'>Greenplum on Twitter</a></li>
+                <li><a href='https://www.youtube.com/channel/UCIC2TGO-4xNSAJFCJXlJNwA'>Greenplum on Youtube</a></li>
               </ul>
             </div>
             <div class='bg-lightgrey'>
@@ -160,6 +161,7 @@
       <h2>Learn More:</h2>
       <div class='cta'><a href='https://github.com/greenplum-db/greenplum-db.github.io/wiki'>Wiki</a></div>
       <div class='cta'><a href='http://gpdb.docs.pivotal.io/'>Documentation</a></div>
+      <div class='cta'><a href='https://www.youtube.com/channel/UCIC2TGO-4xNSAJFCJXlJNwA'>Videos</a></div>
     </div>
 
     <div id='mailing-lists'>


### PR DESCRIPTION
This adds a link to the channel under Evangelism but also under the "Learn More" subsection in order to give it more attention. Seems a shame to not highlight such good content.