### PR TITLE
Update VM download link to point to 4.3.8.1 version

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <img src='images/logo-greenplum.png' alt='Greenplum Logo'>&reg;
         <h1>The World's First Open Source<br/>Massively Parallel Data Warehouse</h1>
         <div class='cta'><a href='https://github.com/greenplum-db/gpdb'>Get the Code</a></div>
-        <div class='cta'><a href='https://network.pivotal.io/products/pivotal-gpdb#/releases/1624/file_groups/395'>Get the Sandbox VM</a></div>
+        <div class='cta'><a href='https://network.pivotal.io/products/pivotal-gpdb#/releases/1683/file_groups/411'>Get the Sandbox VM</a></div>
         <div class='cta'><a href='http://greenplum.org/gpdb-sandbox-tutorials/'>View the Tutorials</a></div>
       </div>
     </div>


### PR DESCRIPTION
There is a new version of the VM for download, update to point to the latest and greatest release. See also https://github.com/greenplum-db/gpdb-sandbox-tutorials/pull/14 which does the same update for the Tutorials section.