### PR TITLE
Reduce the number of options in top navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,10 +53,8 @@
         <a href="#events">Events</a>
         <a href="https://github.com/greenplum-db/gpdb/wiki">Wiki</a>
         <a href="http://greenplum.org/docs/">Documentation</a>
-        <a href="http://greenplum.org/gpdb-sandbox-tutorials/">Tutorials</a>
+		<a href="#tools">Tools</a>
         <a href="https://hub.docker.com/r/pivotaldata/gpdb-base/">Docker Images</a>
-        <a href="http://greenplum.org/calc">Memory Calculator</a>
-        <a href="https://planchecker.cfapps.io">Plan Checker</a>
       </div>
     </div>
 
@@ -164,6 +162,12 @@
       <div class='cta'><a href='http://greenplum.org/docs/'>Documentation</a></div>
       <div class='cta'><a href='https://www.youtube.com/GreenplumDatabase'>Videos</a></div>
     </div>
+
+	<div id='tools' class='bg-paleblue'>
+	  <h2>DBA Tools:</h2>
+      <div class='cta'><a href="http://greenplum.org/calc">Memory Calculator</a></div>
+      <div class='cta'><a href="https://planchecker.cfapps.io">Plan Checker</a></div>
+	</div>
 
     <div id='mailing-lists'>
       <div class='container center'>

--- a/style/master.css
+++ b/style/master.css
@@ -112,6 +112,9 @@ p {
 .bg-blue {
   background: #1e90ff;
 }
+.bg-paleblue {
+  background: #8fc1f1;
+}
 .bg-stingray {
   background: #93a8b3;
 }
@@ -277,6 +280,34 @@ li:before {
 }
 
 #learnmore .cta a {
+  color: #333333;
+}
+
+#tools {
+  padding: 70px 0;
+  text-align: center;
+}
+
+#tools .container {
+  max-width: 635px;
+}
+
+#tools h2 {
+  color: white;
+  display: inline-block;
+  padding-right: 50px;
+}
+
+#tools .cta {
+  background-color: white;
+  display: inline-block;
+}
+
+#tools .cta:hover {
+  background-color: #f7f7f7;
+}
+
+#tools .cta a {
   color: #333333;
 }
 


### PR DESCRIPTION
The navbar is becoming a bit cluttered and is already breaking to
multiple rows on smaller displays. Break out the tools into a
separate section and remove the tutorials item since it's already
in the set of top callout links.